### PR TITLE
Contributors validation

### DIFF
--- a/src/htdocs/data/comcat/_functions.inc.php
+++ b/src/htdocs/data/comcat/_functions.inc.php
@@ -24,7 +24,10 @@ function get_json_metadata ($dir='.', $metadata_file='index.json') {
     if (!file_exists($index)) {
       continue;
     }
-    $metadata[] = json_decode(file_get_contents($index), true);
+    $json = json_decode(file_get_contents($index), true);
+    if ($json && $f === $json['id']) {
+      $metadata[] = $json;
+    }
   }
 
   return $metadata;

--- a/src/htdocs/data/comcat/contributor/ceri/index.json
+++ b/src/htdocs/data/comcat/contributor/ceri/index.json
@@ -1,8 +1,8 @@
 {
   "id": "ceri",
   "title": "Center for Earthquake Research and Information, Memphis, Tennessee",
-  "url": http://www.memphis.edu/ceri,
-  "aliases": null
+  "url": "http://www.memphis.edu/ceri",
+  "aliases": null,
   "email": "mwithers@memphis.edu",
   "address": {
     "org": "Center for Earthquake Research and Information\nThe University of Memphis",

--- a/src/htdocs/data/comcat/contributor/se/index.json
+++ b/src/htdocs/data/comcat/contributor/se/index.json
@@ -2,7 +2,7 @@
   "id": "se",
   "title": "Center for Earthquake Research and Information",
   "url": "http://www.memphis.edu/ceri/seismic/",
-  "aliases": null
+  "aliases": null,
   "email": "mwithers@memphis.edu",
   "email-name": "Mitch Withers",
   "tel": [


### PR DESCRIPTION
Fix for cooperators logo not displaying on event pages.

CERI and SE metadata updates resulted in invalid json, leading to an ID conflict.  This pr prevents a poorly formatted json file from corrupting the feed (it will just be omitted), and fixes the CERI and SE json metadata files.