### PR TITLE
Update scenario pages to use a catalog-url when one is defined

### DIFF
--- a/src/htdocs/scenarios/catalog/README.md
+++ b/src/htdocs/scenarios/catalog/README.md
@@ -29,7 +29,8 @@ More complete example:
 {
   "id": "nc",
   "title": "Northern California Seismic System, UC Berkeley and USGS Menlo Park",
-  "url": "http://www.ncedc.org/",
+  "attribution-url": "http://www.ncedc.org/",
+  "catalog-url": "https://earthquake.usgs.gov/scenarios/map/#%7B%22feed%22%3A%22nclegacy%22%7D",
   "email": "ncsn@andreas.wr.usgs.gov",
   "address": {
     "org": "U.S. Geological Survey\nSeismology Section",

--- a/src/htdocs/scenarios/catalog/_catalog.inc.php
+++ b/src/htdocs/scenarios/catalog/_catalog.inc.php
@@ -11,7 +11,7 @@ if (!isset($TEMPLATE)) {
 
     $id = $json['id'];
     $title = $json['title'];
-    $url = $json['url'];
+    $url = $json['attribution-url'];
     $logo = '../logos/' . $id . '.svg';
 
     $TITLE = strtoupper($id) . ' (Scenario Catalog)';
@@ -29,11 +29,17 @@ if (!isset($TEMPLATE)) {
   $HEAD = '<link rel="stylesheet" href="/lib/earthquake-list-widget-0.1.2/earthquake-list-widget.css"/>' .
       '<link rel="stylesheet" href="../catalog.css"/>';
 
-  $FOOT = '<script src="/lib/earthquake-list-widget-0.1.2/earthquake-list-widget.js"></script>' .
+  $FOOT = '
+      <script>
+        var CATALOG_URL = "' . $json['catalog-url'] . '"' .
+      '</script>
+
+      <script src="/lib/earthquake-list-widget-0.1.2/earthquake-list-widget.js"></script>' .
       '<script src="../catalog.js"></script>';
 
   include 'template.inc.php';
 }
+
 
 echo '<h2 class="org fn">' . $title . '</h2>';
 

--- a/src/htdocs/scenarios/catalog/aklegacy/index.json
+++ b/src/htdocs/scenarios/catalog/aklegacy/index.json
@@ -1,7 +1,8 @@
 {
   "id": "aklegacy",
   "title": "Alaska Legacy Catalog",
-  "url": null,
+  "attribution-url": null,
+  "catalog-url": null,
   "aliases": null,
   "email": "mewest@alaska.edu",
   "email-name": "Michael West",

--- a/src/htdocs/scenarios/catalog/bssc2014/index.json
+++ b/src/htdocs/scenarios/catalog/bssc2014/index.json
@@ -1,7 +1,8 @@
 {
   "id": "bssc2014",
   "title": "Building Seismic Safety Council 2014 Event Set",
-  "url": null,
+  "attribution-url": null,
+  "catalog-url": "http://usgs.maps.arcgis.com/apps/webappviewer/index.html?id=14d2f75c7c4f4619936dac0d14e1e468",
   "aliases": null,
   "email": "emthompson@usgs.gov",
   "email-name": "Eric Thompson",

--- a/src/htdocs/scenarios/catalog/catalog.js
+++ b/src/htdocs/scenarios/catalog/catalog.js
@@ -1,3 +1,4 @@
+/* global CATALOG_URL */
 'use strict';
 
 
@@ -6,6 +7,7 @@ var EqList = require('listwidget/EqList');
 
 var catalog,
     el,
+    feed,
     url;
 
 el = document.querySelector('.catalog-events');
@@ -13,22 +15,27 @@ if (el) {
   catalog = el.getAttribute('data-catalog');
   if (catalog) {
 
-    el.innerHTML = '<h2>Scenarios</h2>' +
+    if (CATALOG_URL) {
+      url = CATALOG_URL;
+    } else {
+      url = '/scenarios/map/#' + encodeURIComponent(JSON.stringify({'feed': catalog}));
+    }
+
+
+    el.innerHTML =
+        '<h2>Scenarios</h2>' +
         '<div class="scenario-map">' +
           '<img src="/scenarios/images/' + catalog + '.gif" ' +
               'alt="map icon" />' +
           '<div class="description">' +
-            '<a href="/scenarios/map/#' +
-                encodeURIComponent(JSON.stringify({'feed': catalog})) + '">' +
-              'View the Catalog on a Map' +
-            '</a>' +
+            '<a href="' + url + '">' + 'View the Catalog on a Map' + '</a>' +
           '</div>' +
         '</div>' +
         '<div class="scenarios">' +
           '<p class="alert info">Loading scenarios&hellip;</p>' +
         '</div>';
 
-    url = '/fdsnws/scenario/1/query.geojson?' +
+    feed = '/fdsnws/scenario/1/query.geojson?' +
         [
           'callback=eqfeed_callback',
           'starttime=1900-01-01',
@@ -51,7 +58,7 @@ if (el) {
         }
       },
       container: el.querySelector('.scenarios'),
-      feed: url
+      feed: feed
     });
   }
 }

--- a/src/htdocs/scenarios/catalog/gllegacy/index.json
+++ b/src/htdocs/scenarios/catalog/gllegacy/index.json
@@ -1,7 +1,8 @@
 {
   "id": "gllegacy",
   "title": "Global Legacy Catalog",
-  "url": null,
+  "attribution-url": null,
+  "catalog-url": null,
   "aliases": null,
   "email": "emthompson@usgs.gov",
   "email-name": "Eric Thompson",

--- a/src/htdocs/scenarios/catalog/hvlegacy/index.json
+++ b/src/htdocs/scenarios/catalog/hvlegacy/index.json
@@ -1,7 +1,8 @@
 {
   "id": "hvlegacy",
   "title": "Hawaii Legacy Catalog",
-  "url": null,
+  "attribution-url": null,
+  "catalog-url": null,
   "aliases": null,
   "email": "emthompson@usgs.gov",
   "email-name": "Eric Thompson",

--- a/src/htdocs/scenarios/catalog/mt2016/index.json
+++ b/src/htdocs/scenarios/catalog/mt2016/index.json
@@ -1,7 +1,8 @@
 {
   "id": "mt2016",
   "title": "2016 Montana Scenarios",
-  "url": null,
+  "attribution-url": null,
+  "catalog-url": null,
   "aliases": null,
   "email": "emthompson@usgs.gov",
   "email-name": "Eric Thompson",

--- a/src/htdocs/scenarios/catalog/nclegacy/index.json
+++ b/src/htdocs/scenarios/catalog/nclegacy/index.json
@@ -1,7 +1,8 @@
 {
   "id": "nclegacy",
   "title": "Northern California Legacy Catalog",
-  "url": null,
+  "attribution-url": null,
+  "catalog-url": null,
   "aliases": null,
   "email": "emthompson@usgs.gov",
   "email-name": "Eric Thompson",

--- a/src/htdocs/scenarios/catalog/nnlegacy/index.json
+++ b/src/htdocs/scenarios/catalog/nnlegacy/index.json
@@ -1,7 +1,8 @@
 {
   "id": "nnlegacy",
   "title": "Nevada Legacy Catalog",
-  "url": null,
+  "attribution-url": null,
+  "catalog-url": null,
   "aliases": null,
   "email": "emthompson@usgs.gov",
   "email-name": "Eric Thompson",

--- a/src/htdocs/scenarios/catalog/sclegacy/index.json
+++ b/src/htdocs/scenarios/catalog/sclegacy/index.json
@@ -1,7 +1,8 @@
 {
   "id": "sclegacy",
   "title": "Southern California Legacy Catalog",
-  "url": null,
+  "attribution-url": null,
+  "catalog-url": null,
   "aliases": null,
   "email": "emthompson@usgs.gov",
   "email-name": "Eric Thompson",

--- a/src/htdocs/scenarios/catalog/uulegacy/index.json
+++ b/src/htdocs/scenarios/catalog/uulegacy/index.json
@@ -1,7 +1,8 @@
 {
   "id": "uulegacy",
   "title": "Utah Legacy Catalog",
-  "url": null,
+  "attribution-url": null,
+  "catalog-url": null,
   "aliases": null,
   "email": "emthompson@usgs.gov",
   "email-name": "Eric Thompson",


### PR DESCRIPTION
split `url` field in index.json into two parameters:
 - `attribution-url`
 - `catalog-url`

If a catalog-url is defined, then it is preferred over the generic catalog search based on the `catalog` id