### PR TITLE
Add optional maxFeatures parameter to Features::toHtml

### DIFF
--- a/src/htdocs/_features.inc.php
+++ b/src/htdocs/_features.inc.php
@@ -1,6 +1,6 @@
 <?php
 
-include_once 'Features.class.php';
+include_once '../lib/Features.class.php';
 
 date_default_timezone_set('UTC');
 

--- a/src/lib/Features.class.php
+++ b/src/lib/Features.class.php
@@ -60,17 +60,21 @@ class Features {
   /**
    * Format Features list as Html.
    *
+   * @param $maxFeatures {Integer}
+   *        number of features to output.
+   *        output all if $maxFeatures is less than zero.
+   *        default 2.
    * @return {String} html.
    */
-  public function toHtml() {
+  public function toHtml($maxFeatures=2) {
     $items = $this->getItems();
     $len = count($items);
 
     $r = '';
     $r .= '<ul class="no-style linklist">';
-    $r .=   $this->getItemHtml($items[0]);
-    $r .=   $this->getItemHtml($items[1]);
-    /* $r .=   $this->getItemHtml($items[3]); */
+    for ($i = 0; $i < $len && ($maxFeatures < 0 || $i < $maxFeatures); $i++) {
+      $r .= $this->getItemHtml($items[$i]);
+    }
     $r .= '</ul>';
 
     return $r;


### PR DESCRIPTION
This change allows a custom number of features, by passing that number to the `toHtml` call.

Note the include path to `Features.class.php` has changed, and from research it would be:
  `include_once '../../lib/Features.class.php'`