### PR TITLE
Add empty shakemap rss, with link to new feeds

### DIFF
--- a/src/htdocs/earthquakes/shakemap/rss.xml
+++ b/src/htdocs/earthquakes/shakemap/rss.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0">
+<channel>
+ <title>USGS Earthquake Shakemaps (DEPRECATED)</title>
+ <description>This feed is not maintained.</description>
+ <link>https://earthquake.usgs.gov/earthquakes/feed/</link>
+ <lastBuildDate>Tue, 13 Feb 2018 16:00:00 +0000</lastBuildDate>
+ <pubDate>Tue, 13 Feb 2018 16:00:00 +0000</pubDate>
+ <ttl>525600</ttl>
+
+ <item>
+  <title>This feed is not maintained.</title>
+  <description>
+    Visit https://earthquake.usgs.gov/earthquakes/feed/
+    for information on available feed formats.
+  </description>
+  <link>https://earthquake.usgs.gov/earthquakes/feed/</link>
+  <guid isPermaLink="false">shakemap-rss-deprecated</guid>
+  <pubDate>Tue, 13 Feb 2018 16:00:00 +0000</pubDate>
+ </item>
+
+</channel>
+</rss>


### PR DESCRIPTION
Despite 403 Forbidden responses, users continue requesting this content.  Add an empty feed with a link to /earthquakes/feed/ and a 1 year ttl, which can be cached indefinitely.