### PR TITLE
Update links to query software for moving repository to github.com/usgs.

### DIFF
--- a/src/htdocs/data/3dgeologic/documentation.php
+++ b/src/htdocs/data/3dgeologic/documentation.php
@@ -117,7 +117,7 @@ The velocity model is stored in <a href="http://www-2.cs.cmu.edu/~euclid/">Etree
 <h3>Documentation</h3>
 
 <ul>
-  <li><a href="https://github.com/baagaard-usgs/cencalvm">Query software</a></li>
+  <li><a href="https://github.com/usgs/earthquake-cencalvm">Query software</a></li>
   <li>Version <a href="velocitymodel_history.php">history</a></li>
 </li>
 

--- a/src/htdocs/data/3dgeologic/download.php
+++ b/src/htdocs/data/3dgeologic/download.php
@@ -54,5 +54,5 @@ if (!isset($TEMPLATE)) {
   <li><a href="ftp://ehzftp.wr.usgs.gov/baagaard/cencalvm/database/MD5SUMS">Unompressed files</a></li>
   </ul>
 <li>Model query software
-  <p>This software library is required to query the seismic velocity model for physical properties. The software and its documentation are available at <a href="https://github.com/baagaard-usgs/cencalvm">github.com/baagaard-usgs/cencalvm</a>.</p>
+  <p>This software library is required to query the seismic velocity model for physical properties. The software and its documentation are available at <a href="https://github.com/usgs/earthquake-cencalvm">github.com/usgs/earthquake-cencalvm</a>.</p>
 </ul>


### PR DESCRIPTION
Update links to query software as a result of moving the repository to github.com/usgs.