### PR TITLE
Adding null aliases key to metadata files that were missing it.

### DIFF
--- a/src/htdocs/data/comcat/contributor/cgs/index.json
+++ b/src/htdocs/data/comcat/contributor/cgs/index.json
@@ -8,5 +8,6 @@
       "type": "Voice",
       "value": "+1-916-322-3105"
     }
-  ]
+  ],
+  "aliases": null
 }

--- a/src/htdocs/data/comcat/contributor/ew/index.json
+++ b/src/htdocs/data/comcat/contributor/ew/index.json
@@ -9,5 +9,6 @@
       "type": "Voice",
       "value": "+1-626-583-7225"
     }
-  ]
+  ],
+  "aliases": null
 }


### PR DESCRIPTION
Without this it causes server side errors. All contributor json files should have an aliases array. Leave value null (as done here) if not applicable.