### PR TITLE
Data availability

### DIFF
--- a/src/htdocs/data/comcat/data-availability.php
+++ b/src/htdocs/data/comcat/data-availability.php
@@ -6,6 +6,16 @@
     $TITLE = 'ComCat Documentation - Data Availability';
     $NAVIGATION = true;
 
+    date_default_timezone_set('UTC');
+    define('RFC_DATE', 'D, d M Y H:i:s \G\M\T');
+    $time = time();
+    $lastModified = gmdate(RFC_DATE, $time);
+    $MAX_AGE = 86400; // 1 day
+
+    header('Cache-Control: public, max-age=' . $MAX_AGE);
+    header('Expires: ' . gmdate(RFC_DATE, $time + $MAX_AGE));
+    header('Last-Modified: ' . $lastModified);
+
     $catalogUrl = 'https://earthquake.usgs.gov/data/comcat/catalog/index.json.php';
     $catalogs = json_decode(file_get_contents($catalogUrl), true);
 
@@ -43,7 +53,7 @@
   }
 ?>
 
-<h2>Data Availability as of 2016-08-15</h2>
+<h2>Data Availability as of <?= $lastModified ?></h2>
 <table>
   <thead>
     <tr>


### PR DESCRIPTION
Notes

- Caches results for 1 day. This avoids unnecessary DB queries that are slow and can slow down other ComCat requests.
- Some of the details are lost (e.g. update frequencies to PDE based on specific time ranges)
- Catalog details (name, url, etc...) are obtained from production always (regardless of where you are viewing the page from)
- On development you may see some strange results in the dates. Development has some strange data that can't be properly parsed. This is known to not be a problem on production.