### PR TITLE
Move errata page to deleted, update wording

### DIFF
--- a/src/htdocs/earthquakes/browse/deleted.js
+++ b/src/htdocs/earthquakes/browse/deleted.js
@@ -8,15 +8,15 @@ var endtime, starttime, url;
 endtime = new Date(Date.UTC(options.year + 1, 0, 1));
 starttime = new Date(Date.UTC(options.year, 0, 1));
 url =
-	"https://earthquake.usgs.gov/fdsnws/event/1/query.geojson?" +
+	"/fdsnws/event/1/query.geojson?" +
 	[
-		// "endtime=" + endtime.toISOString(),
-		"producttype=deleted-text",
+		"endtime=" + endtime.toISOString(),
 		"starttime=" + starttime.toISOString(),
-		"includedeleted=true"
+		"includedeleted=only",
+		"minmag=2.5",
 	].join("&");
 
 EqList({
 	container: document.querySelector(options.el),
-	feed: url
+	feed: url,
 });

--- a/src/htdocs/earthquakes/browse/deleted.php
+++ b/src/htdocs/earthquakes/browse/deleted.php
@@ -2,7 +2,7 @@
 
 if (!isset($TEMPLATE)) {
   date_default_timezone_set('UTC');
-  $min_year = 2010;
+  $min_year = 1900;
   $current_year = intval(date('Y'));
   $year = isset($_GET['year']) ? intval($_GET['year']) : $current_year;
   if ($year < $min_year || $year > $current_year) {
@@ -10,13 +10,12 @@ if (!isset($TEMPLATE)) {
     // TODO Print error message
     exit();
   }
-  $year = 2010;
   $options = array();
   $options['el'] = '#earthquake-list';
   $options['year'] = $year;
 
 
-  $TITLE = ' Errata for Latest Earthquakes - ' . $year;
+  $TITLE = 'M2.5+ Deleted Earthquakes - ' . $year;
   $NAVIGATION = true;
   $HEAD = '
     <link rel="stylesheet" href="/lib/earthquake-list-widget-1.0.1/earthquake-list-widget.css"/>
@@ -27,7 +26,7 @@ if (!isset($TEMPLATE)) {
     <script>
       var options = ' . json_encode($options) . ';
     </script>
-    <script src="errata.js"></script>
+    <script src="deleted.js"></script>
   ';
   include 'template.inc.php';
 }
@@ -35,32 +34,17 @@ if (!isset($TEMPLATE)) {
 ?>
 
 <p>
-Beginning in 2010, we have posted information here regarding errors in the
-Real-time Earthquake system that led to erroneous information getting posted
-on the website or distributed.
-</p>
-
-<p>
-The USGS and networks contributing to the Advance National Seismic System
-(ANSS) take great effort to provide accurate and timely earthquake information.Occasionally our systems produce erroneous information that is released to the
+The USGS and networks contributing to the Advanced National Seismic System (ANSS)
+take great effort to provide accurate and timely earthquake information.
+Occasionally our systems produce erroneous information that is released to the
 public via our web pages or Earthquake Notification System. These mistakes are
 generally promptly identified by seismologists, removed from our web pages, and
-“delete” e-mails are sent through ENS. In the interest of rapidly providing
-earthquake information to the public, most of the information about earthquakes
-that occur in the USA is automatically posted to the web and ENS if it meets
-quality standards. There is a trade-off between the speed of our earthquake notifications and number of false alarms in the same way that any kind of
-"breaking news" story may have substantial changes or corrections as more information is received. The faster we release earthquake locations and
-magnitudes, the more likely it is that the information may be erroneous.
-Experience demonstrates that imposing more restrictive quality standards
-prevents the release of legitimate earthquake information. Here we document
-serious errors that have resulted in the distribution of flawed information to response organizations and the public. Hopefully this discussion will provide
-our users with a better understanding of our system.
+“delete” e-mails are sent through ENS.  This page lists events that have been deleted.
 </p>
 
 
 <div class="significant-wrapper">
-<!--
-  <form action="significant.php?year=<?php echo $year ?>">
+  <form action="deleted.php?year=<?php echo $year ?>">
     <label for="year" class="significant-year-label">
       Enter a year from <?php echo $min_year ?> to
           <?php echo $current_year ?>
@@ -71,7 +55,6 @@ our users with a better understanding of our system.
         step="1" value="<?php echo $year ?>" autofocus/>
     <button type="submit" class="significant-year-button">Search</button>
   </form>
--->
 
   <div id="earthquake-list">
     <noscript>


### PR DESCRIPTION
Moved errata page for now to instead list deleted events.

Uses `includedeleted=only`, which has only be deployed to staging for now.  This page is not linked for now and is being prepared for a NIC proposal.